### PR TITLE
fix(docs): disable building adapters during docs.rs build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1054,7 +1054,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-component-adapters"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-component-adapters"
-version = "0.2.2"
+version = "0.2.3"
 description = "wasmCloud component adapters"
 authors = ["The wasmCloud Team"]
 categories = ["wasm"]
@@ -10,6 +10,13 @@ repository = "https://github.com/wasmCloud/wasmcloud-component-adapters"
 
 [badges.maintenance]
 status = "actively-developed"
+
+[features]
+default = ["build-adapters"]
+build-adapters = []
+
+[package.metadata.docs.rs]
+features = [] # skip building adapters (which requires internet access)
 
 [target.'cfg(not(windows))'.build-dependencies]
 nix-nar = { workspace = true }

--- a/build.rs
+++ b/build.rs
@@ -172,20 +172,23 @@ async fn main() -> anyhow::Result<()> {
     println!("cargo:rerun-if-env-changed=WASI_PREVIEW1_COMMAND_COMPONENT_ADAPTER");
     println!("cargo:rerun-if-env-changed=WASI_PREVIEW1_REACTOR_COMPONENT_ADAPTER");
 
-    let out_dir = env::var("OUT_DIR")
-        .map(PathBuf::from)
-        .context("failed to lookup `OUT_DIR`")?;
-    try_join!(
-        upsert_artifact(
-            "WASI_PREVIEW1_COMMAND_COMPONENT_ADAPTER",
-            &WASI_PREVIEW1_COMMAND_COMPONENT_ADAPTER_LOCK,
-            out_dir.join("wasi_snapshot_preview1.command.wasm")
-        ),
-        upsert_artifact(
-            "WASI_PREVIEW1_REACTOR_COMPONENT_ADAPTER",
-            &WASI_PREVIEW1_REACTOR_COMPONENT_ADAPTER_LOCK,
-            out_dir.join("wasi_snapshot_preview1.reactor.wasm")
-        ),
-    )?;
+    #[cfg(feature = "build-adapters")]
+    {
+        let out_dir = env::var("OUT_DIR")
+            .map(PathBuf::from)
+            .context("failed to lookup `OUT_DIR`")?;
+        try_join!(
+            upsert_artifact(
+                "WASI_PREVIEW1_COMMAND_COMPONENT_ADAPTER",
+                &WASI_PREVIEW1_COMMAND_COMPONENT_ADAPTER_LOCK,
+                out_dir.join("wasi_snapshot_preview1.command.wasm")
+            ),
+            upsert_artifact(
+                "WASI_PREVIEW1_REACTOR_COMPONENT_ADAPTER",
+                &WASI_PREVIEW1_REACTOR_COMPONENT_ADAPTER_LOCK,
+                out_dir.join("wasi_snapshot_preview1.reactor.wasm")
+            ),
+        )?;
+    }
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,17 @@
 //! wasmCloud component adapters
 
 /// WASI preview1 -> preview2 component adapter for components of "command" type
+#[cfg(feature = "build-adapters")]
 pub const WASI_PREVIEW1_COMMAND_COMPONENT_ADAPTER: &[u8] =
     include_bytes!(env!("WASI_PREVIEW1_COMMAND_COMPONENT_ADAPTER"));
 
+#[cfg(not(feature = "build-adapters"))]
+pub const WASI_PREVIEW1_COMMAND_COMPONENT_ADAPTER: &[u8] = &[];
+
+#[cfg(feature = "build-adapters")]
 /// WASI preview1 -> preview2 component adapter for components of "reactor" type
 pub const WASI_PREVIEW1_REACTOR_COMPONENT_ADAPTER: &[u8] =
     include_bytes!(env!("WASI_PREVIEW1_REACTOR_COMPONENT_ADAPTER"));
+
+#[cfg(not(feature = "build-adapters"))]
+pub const WASI_PREVIEW1_REACTOR_COMPONENT_ADAPTER: &[u8] = &[];


### PR DESCRIPTION
## Feature or Problem
This adds a `build-adapters` feature flag, which is enabled by default. When disabled (during docs.rs builds), we skip building the component adapters (which requires internet access)

## Related Issues
Resolves https://github.com/wasmCloud/wash/issues/831