### PR TITLE
fix(docs): disable building adapters during docs.rs build (for real)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1054,7 +1054,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-component-adapters"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-component-adapters"
-version = "0.2.3"
+version = "0.2.4"
 description = "wasmCloud component adapters"
 authors = ["The wasmCloud Team"]
 categories = ["wasm"]
@@ -16,7 +16,7 @@ default = ["build-adapters"]
 build-adapters = []
 
 [package.metadata.docs.rs]
-features = [] # skip building adapters (which requires internet access)
+no-default-features = true # skip building adapters (which requires internet access)
 
 [target.'cfg(not(windows))'.build-dependencies]
 nix-nar = { workspace = true }


### PR DESCRIPTION
I thought `features = []` disabled all features, but it simply doesn't add any features. We need `no-default-features` to disable `build-adapters` during docs.rs builds