### PR TITLE
refactor: replace `build-adapters` feature by `docs`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,11 +12,11 @@ repository = "https://github.com/wasmCloud/wasmcloud-component-adapters"
 status = "actively-developed"
 
 [features]
-default = ["build-adapters"]
-build-adapters = []
+# skip fetching adapters (which requires network access)
+docs = []
 
 [package.metadata.docs.rs]
-no-default-features = true # skip building adapters (which requires internet access)
+features = ["docs"]
 
 [target.'cfg(not(windows))'.build-dependencies]
 nix-nar = { workspace = true }

--- a/build.rs
+++ b/build.rs
@@ -172,11 +172,23 @@ async fn main() -> anyhow::Result<()> {
     println!("cargo:rerun-if-env-changed=WASI_PREVIEW1_COMMAND_COMPONENT_ADAPTER");
     println!("cargo:rerun-if-env-changed=WASI_PREVIEW1_REACTOR_COMPONENT_ADAPTER");
 
-    #[cfg(feature = "build-adapters")]
-    {
-        let out_dir = env::var("OUT_DIR")
-            .map(PathBuf::from)
-            .context("failed to lookup `OUT_DIR`")?;
+    let out_dir = env::var("OUT_DIR")
+        .map(PathBuf::from)
+        .context("failed to lookup `OUT_DIR`")?;
+    if cfg!(feature = "docs") {
+        let path = out_dir.join("stub.wasm");
+        File::create(&path)
+            .await
+            .context("failed to create stub Wasm file")?;
+        println!(
+            "cargo:rustc-env=WASI_PREVIEW1_COMMAND_COMPONENT_ADAPTER={}",
+            path.display(),
+        );
+        println!(
+            "cargo:rustc-env=WASI_PREVIEW1_REACTOR_COMPONENT_ADAPTER={}",
+            path.display(),
+        );
+    } else {
         try_join!(
             upsert_artifact(
                 "WASI_PREVIEW1_COMMAND_COMPONENT_ADAPTER",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,17 +1,9 @@
 //! wasmCloud component adapters
 
 /// WASI preview1 -> preview2 component adapter for components of "command" type
-#[cfg(feature = "build-adapters")]
 pub const WASI_PREVIEW1_COMMAND_COMPONENT_ADAPTER: &[u8] =
     include_bytes!(env!("WASI_PREVIEW1_COMMAND_COMPONENT_ADAPTER"));
 
-#[cfg(not(feature = "build-adapters"))]
-pub const WASI_PREVIEW1_COMMAND_COMPONENT_ADAPTER: &[u8] = &[];
-
-#[cfg(feature = "build-adapters")]
 /// WASI preview1 -> preview2 component adapter for components of "reactor" type
 pub const WASI_PREVIEW1_REACTOR_COMPONENT_ADAPTER: &[u8] =
     include_bytes!(env!("WASI_PREVIEW1_REACTOR_COMPONENT_ADAPTER"));
-
-#[cfg(not(feature = "build-adapters"))]
-pub const WASI_PREVIEW1_REACTOR_COMPONENT_ADAPTER: &[u8] = &[];


### PR DESCRIPTION
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
---> 

Skipping the adapter fetch is only useful for documentation purposes, introduce `docs` feature specifically for this purpose, such that this crate could still be used with of without default features enabled downstream

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->
#10 
#11 

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [ ] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [ ] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
