### PR TITLE
build: update dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1081,7 +1081,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-component-adapters"
-version = "0.9.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-component-adapters"
-version = "0.10.0"
+version = "0.11.0"
 description = "wasmCloud component adapters"
 authors = ["The wasmCloud Team"]
 categories = ["wasm"]

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "advisory-db": {
       "flake": false,
       "locked": {
-        "lastModified": 1713971667,
-        "narHash": "sha256-VtlITecqZHZcm/Fzfa+0IP7I3gcFe5AS+AG0Tv1qIHk=",
+        "lastModified": 1721582928,
+        "narHash": "sha256-nlnB4V0pFo+hAZpyAixAOYWxhVNFyDHGazXnz7PhrEk=",
         "owner": "rustsec",
         "repo": "advisory-db",
-        "rev": "1d1431ceb4d312c0d5c98be63d518b5d472a1149",
+        "rev": "c0b44f487d8d67d1c6cd369917eb684eff918b64",
         "type": "github"
       },
       "original": {
@@ -21,15 +21,16 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1713979152,
-        "narHash": "sha256-apdecPuh8SOQnkEET/kW/UcfjCRb8JbV5BKjoH+DcP4=",
+        "lastModified": 1717383740,
+        "narHash": "sha256-559HbY4uhNeoYvK3H6AMZAtVfmR3y8plXZ1x6ON/cWU=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "a5eca68a2cf11adb32787fc141cddd29ac8eb79c",
+        "rev": "b65673fce97d277934488a451724be94cc62499a",
         "type": "github"
       },
       "original": {
         "owner": "ipetkov",
+        "ref": "v0.17.3",
         "repo": "crane",
         "type": "github"
       }
@@ -80,11 +81,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1714112748,
-        "narHash": "sha256-jq6Cpf/pQH85p+uTwPPrGG8Ky/zUOTwMJ7mcqc5M4So=",
+        "lastModified": 1721629802,
+        "narHash": "sha256-GKlvM9M0mkKJrL6N1eMG4DrROO25Ds1apFw3/b8594w=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "3ae4b908a795b6a3824d401a0702e11a7157d7e1",
+        "rev": "1270fb024c6987dd825a20cd27319384a8d8569e",
         "type": "github"
       },
       "original": {
@@ -255,16 +256,15 @@
         "nix-log": "nix-log",
         "nixlib": "nixlib_3",
         "nixpkgs-darwin": "nixpkgs-darwin",
-        "nixpkgs-jshon": "nixpkgs-jshon",
         "nixpkgs-nixos": "nixpkgs-nixos",
         "rust-overlay": "rust-overlay_2"
       },
       "locked": {
-        "lastModified": 1714205878,
-        "narHash": "sha256-LT/DCBfmR9cO3DWWqKAILvqn2rU2En/Qj1jWFNe1Qy4=",
+        "lastModified": 1721715875,
+        "narHash": "sha256-sxBjYkkpIqSeSf3wuNUHNnmQ7gtb9tCE8rjpKQjyUJQ=",
         "owner": "rvolosatovs",
         "repo": "nixify",
-        "rev": "8c9f5207c88a4d3a12dd7be55515a05b44c9c272",
+        "rev": "934d972478fff10b1eb52d2b3810d3ccfd11ce4a",
         "type": "github"
       },
       "original": {
@@ -329,11 +329,11 @@
     },
     "nixlib_3": {
       "locked": {
-        "lastModified": 1713660444,
-        "narHash": "sha256-2bVnrEGyWJhRNKspzfTJmVD/fsH9HQURD4cWpz79Ulw=",
+        "lastModified": 1721523216,
+        "narHash": "sha256-/NjnIKkBoqKdvOS8unooDg0HqMaRUwYLbyn0ntjEckQ=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "6882347415e352cfc9c277cc01f73e0f5cb7b93c",
+        "rev": "31a99025ce3784c20dd11dafa5260e80e314f59e",
         "type": "github"
       },
       "original": {
@@ -344,11 +344,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1713349283,
-        "narHash": "sha256-2bjFu3+1zPWZPPGqF+7rumTvEwmdBHBhjPva/AMSruQ=",
+        "lastModified": 1714656196,
+        "narHash": "sha256-kjQkA98lMcsom6Gbhw8SYzmwrSo+2nruiTcTZp5jK7o=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2e359fb3162c85095409071d131e08252d91a14f",
+        "rev": "94035b482d181af0a0f8f77823a790b256b7c3cc",
         "type": "github"
       },
       "original": {
@@ -360,48 +360,32 @@
     },
     "nixpkgs-darwin": {
       "locked": {
-        "lastModified": 1714139560,
-        "narHash": "sha256-Hm/iaa+glj41UWVycGWYAnUm9iovmxWHrwbWiN6kLYg=",
+        "lastModified": 1721662280,
+        "narHash": "sha256-veJoWy9VCxWaBeLYUD0BqTu2fqMvDg98TxSFau7ewaA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "adac2842e7b44a6dfe2c589e5dab2d532f4e8315",
+        "rev": "ea73e7ae9dea53d112cb08fb78f4e00d1f686c54",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixpkgs-23.11-darwin",
+        "ref": "nixpkgs-24.05-darwin",
         "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-jshon": {
-      "locked": {
-        "lastModified": 1701781644,
-        "narHash": "sha256-z6MHVdvNM6PnwxofjyCTXYrDCRB6dXs82lMyAxfK2ik=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "89023fc074c2333ec5f1d28075602c94341655d2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "89023fc074c2333ec5f1d28075602c94341655d2",
         "type": "github"
       }
     },
     "nixpkgs-nixos": {
       "locked": {
-        "lastModified": 1713995372,
-        "narHash": "sha256-fFE3M0vCoiSwCX02z8VF58jXFRj9enYUSTqjyHAjrds=",
+        "lastModified": 1721548954,
+        "narHash": "sha256-7cCC8+Tdq1+3OPyc3+gVo9dzUNkNIQfwSDJ2HSi2u3o=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "dd37924974b9202f8226ed5d74a252a9785aedf8",
+        "rev": "63d37ccd2d178d54e7fb691d7ec76000740ea24a",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-23.11",
+        "ref": "nixos-24.05",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -432,11 +416,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1714031783,
-        "narHash": "sha256-xS/niQsq1CQPOe4M4jvVPO2cnXS/EIeRG5gIopUbk+Q=",
+        "lastModified": 1721577031,
+        "narHash": "sha256-LH3YPNUpJeCjiyf0yaYKxgCjUFtlB41Tr2tBTMGH//s=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "56bee2ddafa6177b19c631eedc88d43366553223",
+        "rev": "4afe0d5393cdedde58881295752fe68acb3148ae",
         "type": "github"
       },
       "original": {
@@ -494,21 +478,17 @@
     },
     "rust-overlay_2": {
       "inputs": {
-        "flake-utils": [
-          "nixify",
-          "flake-utils"
-        ],
         "nixpkgs": [
           "nixify",
           "nixpkgs-nixos"
         ]
       },
       "locked": {
-        "lastModified": 1714097613,
-        "narHash": "sha256-044xbpBszupqN3nl/CGOCJtTQ4O6Aca81mJpX45i8/I=",
+        "lastModified": 1721614891,
+        "narHash": "sha256-1yGOh8w/yhWAZ2NJR9N/shQ1tx2n9fmGe0XrDE00i9U=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "2a42c742ab04b61d9b2f1edf392842cf9f27ebfd",
+        "rev": "424a759557ed4c01cf9dbbf79a714150d64a90ad",
         "type": "github"
       },
       "original": {
@@ -535,25 +515,25 @@
     "wasi-preview1-command-component-adapter": {
       "flake": false,
       "locked": {
-        "narHash": "sha256-qUHAd8KGTqTyAJLY1X2j3s4AvlTXPYaizpBkeOwUFdc=",
+        "narHash": "sha256-x0ZY0SoC43SqnlGdFqetuHDgW5pJxeIANughaSfiDNs=",
         "type": "file",
-        "url": "https://github.com/bytecodealliance/wasmtime/releases/download/v20.0.0/wasi_snapshot_preview1.command.wasm"
+        "url": "https://github.com/bytecodealliance/wasmtime/releases/download/v23.0.1/wasi_snapshot_preview1.command.wasm"
       },
       "original": {
         "type": "file",
-        "url": "https://github.com/bytecodealliance/wasmtime/releases/download/v20.0.0/wasi_snapshot_preview1.command.wasm"
+        "url": "https://github.com/bytecodealliance/wasmtime/releases/download/v23.0.1/wasi_snapshot_preview1.command.wasm"
       }
     },
     "wasi-preview1-reactor-component-adapter": {
       "flake": false,
       "locked": {
-        "narHash": "sha256-v0C3DhPdXKcw0yBtaXfEDHTXKHAQ4m9oLbGRG8A+xKY=",
+        "narHash": "sha256-7vQ1M9qHpNfW8n5DkMcLlpKrB3wPJN2fet3NvHyBYxM=",
         "type": "file",
-        "url": "https://github.com/bytecodealliance/wasmtime/releases/download/v20.0.0/wasi_snapshot_preview1.reactor.wasm"
+        "url": "https://github.com/bytecodealliance/wasmtime/releases/download/v23.0.1/wasi_snapshot_preview1.reactor.wasm"
       },
       "original": {
         "type": "file",
-        "url": "https://github.com/bytecodealliance/wasmtime/releases/download/v20.0.0/wasi_snapshot_preview1.reactor.wasm"
+        "url": "https://github.com/bytecodealliance/wasmtime/releases/download/v23.0.1/wasi_snapshot_preview1.reactor.wasm"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -14,9 +14,9 @@
 
   inputs.nixify.url = "github:rvolosatovs/nixify";
   inputs.wasi-preview1-command-component-adapter.flake = false;
-  inputs.wasi-preview1-command-component-adapter.url = "https://github.com/bytecodealliance/wasmtime/releases/download/v20.0.0/wasi_snapshot_preview1.command.wasm";
+  inputs.wasi-preview1-command-component-adapter.url = "https://github.com/bytecodealliance/wasmtime/releases/download/v23.0.1/wasi_snapshot_preview1.command.wasm";
   inputs.wasi-preview1-reactor-component-adapter.flake = false;
-  inputs.wasi-preview1-reactor-component-adapter.url = "https://github.com/bytecodealliance/wasmtime/releases/download/v20.0.0/wasi_snapshot_preview1.reactor.wasm";
+  inputs.wasi-preview1-reactor-component-adapter.url = "https://github.com/bytecodealliance/wasmtime/releases/download/v23.0.1/wasi_snapshot_preview1.reactor.wasm";
 
   outputs = {
     nixify,


### PR DESCRIPTION
Flake lock file updates:

```
• Updated input 'nixify':
    'github:rvolosatovs/nixify/8c9f5207c88a4d3a12dd7be55515a05b44c9c272' (2024-04-27)
  → 'github:rvolosatovs/nixify/934d972478fff10b1eb52d2b3810d3ccfd11ce4a' (2024-07-23)
• Updated input 'nixify/advisory-db':
    'github:rustsec/advisory-db/1d1431ceb4d312c0d5c98be63d518b5d472a1149' (2024-04-24)
  → 'github:rustsec/advisory-db/c0b44f487d8d67d1c6cd369917eb684eff918b64' (2024-07-21)
• Updated input 'nixify/crane':
    'github:ipetkov/crane/a5eca68a2cf11adb32787fc141cddd29ac8eb79c' (2024-04-24)
  → 'github:ipetkov/crane/b65673fce97d277934488a451724be94cc62499a' (2024-06-03)
• Updated input 'nixify/crane/nixpkgs':
    'github:NixOS/nixpkgs/2e359fb3162c85095409071d131e08252d91a14f' (2024-04-17)
  → 'github:NixOS/nixpkgs/94035b482d181af0a0f8f77823a790b256b7c3cc' (2024-05-02)
• Updated input 'nixify/fenix':
    'github:nix-community/fenix/3ae4b908a795b6a3824d401a0702e11a7157d7e1' (2024-04-26)
  → 'github:nix-community/fenix/1270fb024c6987dd825a20cd27319384a8d8569e' (2024-07-22)
• Updated input 'nixify/fenix/rust-analyzer-src':
    'github:rust-lang/rust-analyzer/56bee2ddafa6177b19c631eedc88d43366553223' (2024-04-25)
  → 'github:rust-lang/rust-analyzer/4afe0d5393cdedde58881295752fe68acb3148ae' (2024-07-21)
• Updated input 'nixify/nixlib':
    'github:nix-community/nixpkgs.lib/6882347415e352cfc9c277cc01f73e0f5cb7b93c' (2024-04-21)
  → 'github:nix-community/nixpkgs.lib/31a99025ce3784c20dd11dafa5260e80e314f59e' (2024-07-21)
• Updated input 'nixify/nixpkgs-darwin':
    'github:nixos/nixpkgs/adac2842e7b44a6dfe2c589e5dab2d532f4e8315' (2024-04-26)
  → 'github:nixos/nixpkgs/ea73e7ae9dea53d112cb08fb78f4e00d1f686c54' (2024-07-22)
• Removed input 'nixify/nixpkgs-jshon'
• Updated input 'nixify/nixpkgs-nixos':
    'github:nixos/nixpkgs/dd37924974b9202f8226ed5d74a252a9785aedf8' (2024-04-24)
  → 'github:nixos/nixpkgs/63d37ccd2d178d54e7fb691d7ec76000740ea24a' (2024-07-21)
• Updated input 'nixify/rust-overlay':
    'github:oxalica/rust-overlay/2a42c742ab04b61d9b2f1edf392842cf9f27ebfd' (2024-04-26)
  → 'github:oxalica/rust-overlay/424a759557ed4c01cf9dbbf79a714150d64a90ad' (2024-07-22)
• Removed input 'nixify/rust-overlay/flake-utils'
• Updated input 'wasi-preview1-command-component-adapter':
    'https://github.com/bytecodealliance/wasmtime/releases/download/v20.0.0/wasi_snapshot_preview1.command.wasm?narHash=sha256-qUHAd8KGTqTyAJLY1X2j3s4AvlTXPYaizpBkeOwUFdc%3D'
  → 'https://github.com/bytecodealliance/wasmtime/releases/download/v23.0.1/wasi_snapshot_preview1.command.wasm?narHash=sha256-x0ZY0SoC43SqnlGdFqetuHDgW5pJxeIANughaSfiDNs%3D'
• Updated input 'wasi-preview1-reactor-component-adapter':
    'https://github.com/bytecodealliance/wasmtime/releases/download/v20.0.0/wasi_snapshot_preview1.reactor.wasm?narHash=sha256-v0C3DhPdXKcw0yBtaXfEDHTXKHAQ4m9oLbGRG8A%2BxKY%3D'
  → 'https://github.com/bytecodealliance/wasmtime/releases/download/v23.0.1/wasi_snapshot_preview1.reactor.wasm?narHash=sha256-7vQ1M9qHpNfW8n5DkMcLlpKrB3wPJN2fet3NvHyBYxM%3D'

```
## Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
